### PR TITLE
Maven 3 build problems fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
     <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
-        <version>0.21.0-SNAPSHOT</version>
+        <version>0.22.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapred</artifactId>
-        <version>0.21.0-SNAPSHOT</version>
+        <version>0.22.0</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+	<version>2.8.1</version>
         <configuration>
           <linksource>true</linksource>
           <includeDependencySources>true</includeDependencySources>
@@ -55,6 +56,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+	<version>2.4</version>
         <configuration>
           <archive>
             <manifest>
@@ -87,6 +89,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+	<version>2.4</version>
         <executions>
           <execution>
             <id>unpack-dependencies</id>
@@ -100,6 +103,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+	<version>2.4</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>


### PR DESCRIPTION
This PR adds version tags for each plugin in the pom.xml in order to fix build problems using Maven 3. Additionally I changed the version of Hadoop to 0.22.0 and tested it with this version.
